### PR TITLE
omitempty api_version in alertmanager_config

### DIFF
--- a/alerting.go
+++ b/alerting.go
@@ -48,7 +48,7 @@ type AlertmanagerConfig struct {
 	Timeout Duration `yaml:"timeout,omitempty"`
 
 	// The api version of Alertmanager.
-	APIVersion string `yaml:"api_version"`
+	APIVersion string `yaml:"api_version,omitempty"`
 
 	// List of Alertmanager relabel configurations.
 	RelabelConfigs []*RelabelConfig `yaml:"relabel_configs,omitempty"`


### PR DESCRIPTION
In Prometheus config api_version has a default value of [v1](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#alertmanager_config)
use omitempty to make sure that we are not making api_version empty string when encoding